### PR TITLE
Replace double with single quotes

### DIFF
--- a/templates/files/spec/models/account_spec.rb
+++ b/templates/files/spec/models/account_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe Account, type: :model do
   it { should validate_presence_of :email }
   it { should validate_uniqueness_of :email }
-  it { should allow_value("valid@example.com").for(:email) }
-  it { should_not allow_value("invalid").for(:email) }
+  it { should allow_value('valid@example.com').for(:email) }
+  it { should_not allow_value('invalid').for(:email) }
 end


### PR DESCRIPTION
Why:
- Rubocop raises a mistake

This change addresses the need by:
- Replacing the quotes
